### PR TITLE
Patch for backwardSlice.

### DIFF
--- a/chucky/joernInterface/joernsteps/chucky.groovy
+++ b/chucky/joernInterface/joernsteps/chucky.groovy
@@ -60,13 +60,15 @@ Gremlin.defineStep('forwardSlice', [Vertex, Pipe], { symbol ->
 Gremlin.defineStep('backwardSlice', [Vertex, Pipe], { symbol ->
 	_()
 	.copySplit(
-		_(),
-		_().sideEffect{first = true}
+	_(),
+	_().transform{
+		it.sideEffect{first = true;}
 		.inE('REACHES', 'CONTROLS')
 		.filter{it.label == 'CONTROLS' || !first || it.var == symbol}
-		.outV()
+		.outV().gather{it}.scatter()
 		.sideEffect{first = false}
 		.loop(4){it.loops < 5}{true}
+	}.scatter()
 	).fairMerge()
 	.dedup()
 });


### PR DESCRIPTION
Hi,
I think there's a bug in backwardSlice: The sideEffect { first=False } should be executed once all direct neighbors in the graph are processed. Right now, it is processed after one of them has been processed.
I think this patches the issue by gathering neighbors after each execution of the loop and then executing the side-effect. If this is correct, you probably also want to make these changes to forwardSlice.
Fabian
